### PR TITLE
Update urls.py (Django 1.10 compatiblity)

### DIFF
--- a/polls/urls.py
+++ b/polls/urls.py
@@ -1,12 +1,12 @@
 #-*- coding: utf-8 -*-
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from . import views
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', views.IndexView.as_view(), name='index'),
     url(r'^(?P<pk>\d+)/$', views.DetailView.as_view(), name='detail'),
     url(r'^(?P<pk>\d+)/results/$', views.ResultsView.as_view(), name='results'),
     url(r'^(?P<poll_id>\d+)/vote/$', views.vote, name='vote'),
-)
+]


### PR DESCRIPTION
Urlpatterns should be a simple list (patterns module is deprecated since 1.8, removed in 1.10): https://docs.djangoproject.com/en/1.10/topics/http/urls/#example